### PR TITLE
Extract the sleep time into a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The script includes several configurable parameters:
 - Maximum input voltage: 5500mV
 - Benchmark duration: 10 minutes
 - Sample interval: 15 seconds
+- Sleep time before benchmark: 90 seconds
 - **Minimum required samples: 7** (for valid data processing)
 - Voltage increment: 20mV
 - Frequency increment: 25MHz

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -36,6 +36,7 @@ initial_frequency = args.frequency
 # Configuration
 voltage_increment = 20
 frequency_increment = 25
+sleep_time = 90               # Wait 90 seconds before starting the benchmark
 benchmark_time = 600          # 10 minutes benchmark time
 sample_interval = 15          # 15 seconds sample interval
 max_temp = 66                 # Will stop if temperature reaches or exceeds this value
@@ -169,12 +170,12 @@ def restart_system():
         is_interrupt = handling_interrupt
         
         # Restart here as some bitaxes get unstable with bad settings
-        # If not an interrupt, wait 90s for system stabilization as some bitaxes are slow to ramp up
+        # If not an interrupt, wait sleep_time for system stabilization as some bitaxes are slow to ramp up
         if not is_interrupt:
-            print(YELLOW + "Applying new settings and waiting 90s for system stabilization..." + RESET)
+            print(YELLOW + f"Applying new settings and waiting {sleep_time}s for system stabilization..." + RESET)
             response = requests.post(f"{bitaxe_ip}/api/system/restart", timeout=10)
             response.raise_for_status()  # Raise an exception for HTTP errors
-            time.sleep(90)  # Allow 90s time for the system to restart and start hashing
+            time.sleep(sleep_time)  # Allow sleep_time for the system to restart and start hashing
         else:
             print(YELLOW + "Applying final settings..." + RESET)
             response = requests.post(f"{bitaxe_ip}/api/system/restart", timeout=10)


### PR DESCRIPTION
Older BitAxe models take much longer than 90 seconds to reach a stable hash rate. Sometimes it takes 15 minutes.

The [sleep time](https://github.com/mrv777/Bitaxe-Hashrate-Benchmark/blob/main/bitaxe_hashrate_benchmark.py#L177) has to be adjusted to get valid benchmark results. It makes sense to provide the sleep time as an option/variable. The user will find the option in one place with the other settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Made the wait time before starting the benchmark configurable, allowing easier adjustment of the delay period.
- **Documentation**
	- Updated the README to document the new configurable wait time before the benchmark starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->