### PR TITLE
Update bitaxe_hashrate_benchmark.py

### DIFF
--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -16,7 +16,6 @@ except ImportError:
         os.system("")  # rudimentary ANSI enable on Windows
 
 # Compute timestamp for file suffix
-import time
 timestamp = time.strftime("%Y%m%d-%H%M%S")
 
 # ANSI Color Codes


### PR DESCRIPTION
Couple of changes:
- color not working in windows terminal
- suffix in filename in case of voltage/frequency argument
- limited (1 successive) retries in case of overheat (previously any chip overheat reached ended the benchmark)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved support for colored terminal output on Windows systems.
  - Benchmark result files now include voltage and frequency details in filenames for easier identification.

- **Bug Fixes**
  - Enhanced overheating handling during benchmarking by allowing one retry with adjusted settings, preventing repeated failures.

- **Enhancements**
  - Added clearer messages indicating frequency and voltage changes and reasons for stopping tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->