### PR TITLE
Fix asicCount default value for latest firmwares

### DIFF
--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -91,7 +91,7 @@ def fetch_default_settings():
         default_voltage = system_info.get("coreVoltage", 1150)  # Fallback to 1150 if not found
         default_frequency = system_info.get("frequency", 500)  # Fallback to 500 if not found
         small_core_count = system_info.get("smallCoreCount", 0)
-        asic_count = system_info.get("asicCount", 0)
+        asic_count = system_info.get("asicCount", 1) # Fallback to 1 since this param is removed in latest firmware updates
         print(GREEN + f"Current settings determined:\n"
                       f"  Core Voltage: {default_voltage}mV\n"
                       f"  Frequency: {default_frequency}MHz\n"


### PR DESCRIPTION
For latest Bitaxe firmware parameter asicCount is no longer present in api info response. Therefor expected_hashrate always calculates to 0 which seems confusing in output and likely leads to incorrect results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default value for the number of ASICs to 1 when system information is missing this parameter, ensuring more accurate fallback behavior with the latest firmware updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->