### PR TITLE
Add real-time and final hashrate standard deviation calculations to benchmark output

### DIFF
--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -311,7 +311,7 @@ def benchmark_iteration(core_voltage, frequency):
             f"CV: {core_voltage:4d}mV | "
             f"F: {frequency:4d}MHz | "
             f"H: {int(hash_rate):4d} GH/s | "
-            f"SD: {running_sd:.2f} GH/s | "
+            f"SD: {running_sd:3.0f} GH/s | "
             f"IV: {int(voltage):4d}mV | "
             f"T: {int(temp):2d}°C"
         )


### PR DESCRIPTION
This update enhances the benchmarking script by adding both running and final standard deviation calculations for hashrate measurements.

Key changes include:
- Added statistics import and new running_stddev() function for incremental SD computation during sampling.
- Updated benchmark_iteration() to track sum and sum-of-squares (s1, s2) for running SD.
- Display running SD in the live benchmark status line.
- Calculate and display final hashrate standard deviation after trimming to remove potential outliers.
- Included hashrateStdDev in returned results, saved results, and printed summaries.
- Adjusted function return signatures to include standard deviation values.

This provides more insight into hashrate variability during and after benchmarking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Displays per-sample hashrate standard deviation in the live status line.
  - Adds “Hashrate Std Dev” to final summaries, rankings, and printed outputs.
  - Includes hashrate standard deviation in exported JSON for all results, top performers, and most efficient entries.
  - Preserves hashrate standard deviation when saving and restoring best/default results.
  - Introduces a graceful cleanup on exit or interruption that saves results and resets settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->