### PR TITLE
fix: enable unbuffered Python output in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the script
 COPY bitaxe_hashrate_benchmark.py .
 
+# Ensure Python output is sent straight to the container logs without buffering
+ENV PYTHONUNBUFFERED=1
+
 # Set the entrypoint
 ENTRYPOINT ["python", "bitaxe_hashrate_benchmark.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,9 @@ COPY bitaxe_hashrate_benchmark.py .
 # Ensure Python output is sent straight to the container logs without buffering
 ENV PYTHONUNBUFFERED=1
 
+# Default output directory for benchmark results
+RUN mkdir -p /results
+VOLUME /results
+
 # Set the entrypoint
-ENTRYPOINT ["python", "bitaxe_hashrate_benchmark.py"]
+ENTRYPOINT ["python", "bitaxe_hashrate_benchmark.py", "--output-dir", "/results"]

--- a/README.md
+++ b/README.md
@@ -1,166 +1,179 @@
-# Bitaxe Hashrate Benchmark
+# **Bitaxe Hashrate Benchmark**
 
 A Python-based benchmarking tool for optimizing Bitaxe mining performance by testing different voltage and frequency combinations while monitoring hashrate, temperature, and power efficiency.
 
-## Features
+## **Features**
 
-- Automated benchmarking of different voltage/frequency combinations
-- Temperature monitoring and safety cutoffs
-- Power efficiency calculations (J/TH)
-- Automatic saving of benchmark results
-- Graceful shutdown with best settings retention
-- Docker support for easy deployment
+* Automated benchmarking of different voltage/frequency combinations  
+* **Direct setting of specific voltage and frequency from command line**  
+* Temperature monitoring and safety cutoffs  
+* **Power consumption monitoring and reporting (Watts)**  
+* **Fan speed monitoring and reporting (RPM/Percentage)**  
+* Power efficiency calculations (J/TH)  
+* Automatic saving of benchmark results  
+* Graceful shutdown with best settings retention  
+* Docker support for easy deployment
 
-## Prerequisites
+## **Prerequisites**
 
-- Python 3.11 or higher
-- Access to a Bitaxe miner on your network
-- Docker (optional, for containerized deployment)
-- Git (optional, for cloning the repository)
+* Python 3.11 or higher  
+* Access to a Bitaxe miner on your network  
+* Docker (optional, for containerized deployment)  
+* Git (optional, for cloning the repository)
 
-## Installation
+## **Installation**
 
-### Standard Installation
+### **Standard Installation**
 
-1. Clone the repository:
-```bash
-git clone https://github.com/mrv777/Bitaxe-Hashrate-Benchmark.git
-cd Bitaxe-Hashrate-Benchmark
-```
+1. Clone the repository:  
+   git clone https://github.com/mrv777/Bitaxe-Hashrate-Benchmark.git  
+   cd Bitaxe-Hashrate-Benchmark
 
-2. Create and activate a virtual environment:
-```bash
-python -m venv venv
-# On Windows
-venv\Scripts\activate
-# On Linux/Mac
-source venv/bin/activate
-```
+2. Create and activate a virtual environment:  
+   python \-m venv venv  
+   \# On Windows  
+   venv\\Scripts\\activate  
+   \# On Linux/Mac  
+   source venv/bin/activate
 
-3. Install dependencies:
-```bash
-pip install -r requirements.txt
-```
+3. Install dependencies:  
+   pip install \-r requirements.txt
 
-### Docker Installation
+### **Docker Installation**
 
-1. Build the Docker image:
-```bash
-docker build -t bitaxe-benchmark .
-```
+1. Build the Docker image:  
+   docker build \-t bitaxe-benchmark .
 
-## Usage
+## **Usage**
 
-### Standard Usage
+### **Standard Usage (Run Full Benchmark)**
 
-Run the benchmark tool by providing your Bitaxe's IP address:
+Run the benchmark tool by providing your Bitaxe's IP address and initial settings:  
+python bitaxe\_hasrate\_benchmark.py \<bitaxe\_ip\> \-v \<initial\_voltage\> \-f \<initial\_frequency\>
 
-```bash
-python bitaxe_hashrate_benchmark.py <bitaxe_ip>
-```
+**Arguments:**
 
-Optional parameters:
-- `-v, --voltage`: Initial voltage in mV (default: 1150)
-- `-f, --frequency`: Initial frequency in MHz (default: 500)
+* \<bitaxe\_ip\>: **Required.** IP address of your Bitaxe miner (e.g., 192.168.2.26).  
+* \-v, \--voltage: **Optional.** Initial voltage in mV for testing (default: 1150).  
+* \-f, \--frequency: **Optional.** Initial frequency in MHz for testing (default: 500).
 
-Example:
-```bash
-python bitaxe_hashrate_benchmark.py 192.168.2.29 -v 1175 -f 775
-```
+**Example:**  
+python bitaxe\_hasrate\_benchmark.py 192.168.1.136 \-v 1150 \-f 500
 
-### Docker Usage (Optional)
+### **Apply Specific Settings (Without Benchmarking)**
 
-Run the container with your Bitaxe's IP address:
+To quickly apply specific voltage and frequency settings to your Bitaxe without running the full benchmark:  
+python bitaxe\_hasrate\_benchmark.py \<bitaxe\_ip\> \--set-values \-v \<desired\_voltage\_mv\> \-f \<desired\_frequency\_mhz\>
 
-```bash
-docker run --rm bitaxe-benchmark <bitaxe_ip> [options]
-```
+**Arguments:**
 
-Example:
-```bash
-docker run --rm bitaxe-benchmark 192.168.2.26 -v 1200 -f 550
-```
+* \<bitaxe\_ip\>: **Required.** IP address of your Bitaxe miner.  
+* \-s, \--set-values: **Flag.** Activates this mode to only set values and exit.  
+* \-v, \--voltage: **Required.** The exact voltage in mV to apply.  
+* \-f, \--frequency: **Required.** The exact frequency in MHz to apply.
 
-## Configuration
+**Example:**  
+python bitaxe\_hasrate\_benchmark.py 192.168.1.136 \--set-values \-v 1150 \-f 780
 
-The script includes several configurable parameters:
+### **Docker Usage (Optional)**
 
-- Maximum chip temperature: 66°C
-- Maximum VR temperature: 86°C
-- Maximum allowed voltage: 1400mV
-- Minimum allowed voltage: 1000mV
-- Maximum allowed frequency: 1200MHz
-- Maximum power consumption: 40W
-- Minimum allowed frequency: 400MHz
-- Minimum input voltage: 4800mV
-- Maximum input voltage: 5500mV
-- Benchmark duration: 10 minutes
-- Sample interval: 15 seconds
-- **Minimum required samples: 7** (for valid data processing)
-- Voltage increment: 20mV
-- Frequency increment: 25MHz
+Run the container with your Bitaxe's IP address (add \--set-values for that mode):  
+docker run \--rm bitaxe-benchmark \<bitaxe\_ip\> \[options\]
 
-## Output
+Example (Full Benchmark):  
+docker run \--rm bitaxe-benchmark 192.168.2.26 \-v 1200 \-f 550
 
-The benchmark results are saved to `bitaxe_benchmark_results_<ip_address>.json`, containing:
-- Complete test results for all combinations
-- Top 5 performing configurations ranked by hashrate
-- Top 5 most efficient configurations ranked by J/TH
-- For each configuration:
-  - Average hashrate (with outlier removal)
-  - Temperature readings (excluding initial warmup period)
-  - VR temperature readings (when available)
-  - Power efficiency metrics (J/TH)
-  - Input voltage measurements
-  - Voltage/frequency combinations tested
+Example (Set Settings Only):  
+docker run \--rm bitaxe-benchmark 192.168.2.26 \--set-values \-v 1150 \-f 780
 
-## Safety Features
+## **Configuration**
 
-- Automatic temperature monitoring with safety cutoff (66°C chip temp)
-- Voltage regulator (VR) temperature monitoring with safety cutoff (86°C)
-- Input voltage monitoring with minimum threshold (4800mV) and maximum threshold (5500mV)
-- Power consumption monitoring with safety cutoff (40W)
-- Temperature validation (must be above 5°C)
-- Graceful shutdown on interruption (Ctrl+C)
-- Automatic reset to best performing settings after benchmarking
-- Input validation for safe voltage and frequency ranges
-- Hashrate validation to ensure stability
-- Protection against invalid system data
-- Outlier removal from benchmark results
+The script includes several configurable parameters. These can be adjusted in the bitaxe\_hasrate\_benchmark.py file:
 
-## Benchmarking Process
+* Maximum chip temperature: 66°C  
+* Maximum VR temperature: 86°C  
+* Maximum allowed voltage: 1400mV  
+* Minimum allowed voltage: 1000mV  
+* Maximum allowed frequency: 1200MHz  
+* Maximum power consumption: 30W  
+* Minimum allowed frequency: 400MHz  
+* Minimum input voltage: 4800mV  
+* Maximum input voltage: 5500mV  
+* Benchmark duration: 600 seconds (10 minutes per combination)  
+* Sample interval: 15 seconds  
+* Minimum required samples: 7 (for valid data processing)  
+* Voltage increment: 15mV  
+* Frequency increment: 20MHz  
+* **ASIC Configuration:** asic\_count is hardcoded to 1 as it's not always provided by the API. small\_core\_count is fetched from the Bitaxe.
+
+## **Output**
+
+The benchmark results are saved to bitaxe\_benchmark\_results\_\<ip\_address\>.json, containing:
+
+* Complete test results for all combinations  
+* Top 5 performing configurations ranked by hashrate  
+* Top 5 most efficient configurations ranked by J/TH  
+* For each configuration:  
+  * Average hashrate (with outlier removal)  
+  * Temperature readings (excluding initial warmup period)  
+  * VR temperature readings (when available)  
+  * Power efficiency metrics (J/TH)  
+  * **Average Power (Watts)**  
+  * **Average Fan Speed (Percentage or RPM, if available from API)**  
+  * Input voltage measurements  
+  * Voltage/frequency combinations tested  
+  * Error reason (if any) for a specific iteration
+
+## **Safety Features**
+
+* Automatic temperature monitoring with safety cutoff (66°C chip temp)  
+* Voltage regulator (VR) temperature monitoring with safety cutoff (86°C)  
+* Input voltage monitoring with minimum threshold (4800mV) and maximum threshold (5500mV)  
+* Power consumption monitoring with safety cutoff (30W)  
+* Temperature validation (must be above 5°C)  
+* Graceful shutdown on interruption (Ctrl+C)  
+* Automatic reset to best performing settings after benchmarking  
+* Input validation for safe voltage and frequency ranges  
+* Hashrate validation to ensure stability  
+* Protection against invalid system data  
+* Outlier removal from benchmark results
+
+## **Benchmarking Process**
 
 The tool follows this process:
-1. Starts with user-specified or default voltage/frequency
-2. Tests each combination for 20 minutes
-3. Validates hashrate is within 8% of theoretical maximum
-4. Incrementally adjusts settings:
-   - Increases frequency if stable
-   - Increases voltage if unstable
-   - Stops at thermal or stability limits
-5. Records and ranks all successful configurations
-6. Automatically applies the best performing stable settings
-7. Restarts system after each test for stability
+
+1. Starts with user-specified or default voltage/frequency  
+2. Tests each combination for 10 minutes  
+3. Validates hashrate is within 8% of theoretical maximum  
+4. Incrementally adjusts settings:  
+   * Increases frequency if stable  
+   * Increases voltage if unstable  
+   * Stops at thermal or stability limits  
+5. Records and ranks all successful configurations  
+6. Automatically applies the best performing stable settings  
+7. Restarts system after each test for stability  
 8. Allows 90-second stabilization period between tests
 
-## Data Processing
+## **Data Processing**
 
 The tool implements several data processing techniques to ensure accurate results:
-- Removes 3 highest and 3 lowest hashrate readings to eliminate outliers
-- Excludes first 6 temperature readings during warmup period
-- Validates hashrate is within 6% of theoretical maximum
-- Averages power consumption across entire test period
-- Monitors VR temperature when available
-- Calculates efficiency in Joules per Terahash (J/TH)
 
-## Contributing
+* Removes 3 highest and 3 lowest hashrate readings to eliminate outliers  
+* Excludes first 6 temperature readings during warmup period  
+* Validates hashrate is within 6% of theoretical maximum  
+* Averages power consumption across entire test period  
+* Monitors VR temperature when available  
+* Calculates efficiency in Joules per Terahash (J/TH)  
+* **Averages fan speed across entire test period**
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+## **Contributing**
 
-## License
+Contributions are welcome\! Please feel free to submit a Pull Request.
 
-This project is licensed under the GNU General Public License v3.0 - see the [LICENSE](LICENSE) file for details.
+## **License**
 
-## Disclaimer
+This project is licensed under the GNU General Public License v3.0 \- see the [LICENSE](https://www.google.com/search?q=LICENSE) file for details.
+
+## **Disclaimer**
 
 Please use this tool responsibly. Overclocking and voltage modifications can potentially damage your hardware if not done carefully. Always ensure proper cooling and monitor your device during benchmarking.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The tool follows this process:
 
 1. Starts with user-specified or default voltage/frequency  
 2. Tests each combination for 10 minutes  
-3. Validates hashrate is within 8% of theoretical maximum  
+3. Validates hashrate is within 6% of theoretical maximum  
 4. Incrementally adjusts settings:  
    * Increases frequency if stable  
    * Increases voltage if unstable  

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A Python-based benchmarking tool for optimizing Bitaxe mining performance by tes
    ```bash
    python -m venv venv
    # On Windows  
-   venvScriptsactivate
+   venv\Scripts\activate
    # On Linux/Mac  
    source venv/bin/activate
    ```
@@ -48,7 +48,7 @@ A Python-based benchmarking tool for optimizing Bitaxe mining performance by tes
 ### **Docker Installation**
 
 1. Build the Docker image:  
-   `docker build -t bitaxe-benchmark`
+   `docker build -t bitaxe-benchmark .`
 
 ## **Usage**
 

--- a/README.md
+++ b/README.md
@@ -32,25 +32,21 @@ A Python-based benchmarking tool for optimizing Bitaxe mining performance by tes
    ```
 
 2. Create and activate a virtual environment:  
-   ```bash
-   python \-m venv venv  
-   \# On Windows  
-   venv\\Scripts\\activate  
-   \# On Linux/Mac  
-   source venv/bin/activate
-   ```
+   `python -m venv venv`
+   # On Windows  
+   `venvScriptsactivate`
+   # On Linux/Mac  
+   `source venv/bin/activate`
+   
 
-3. Install dependencies:  
-   ```bash
-   pip install \-r requirements.txt
-   ```
+3. Install dependencies:     
+   `pip install -r requirements.txt`
+
 
 ### **Docker Installation**
 
 1. Build the Docker image:  
-   ```bash
-   docker build \-t bitaxe-benchmark
-   ```
+   `docker build -t bitaxe-benchmark`
 
 ## **Usage**
 
@@ -58,59 +54,59 @@ A Python-based benchmarking tool for optimizing Bitaxe mining performance by tes
 
 Run the benchmark tool by providing your Bitaxe's IP address and initial settings:  
 ```bash
-python bitaxe\_hasrate\_benchmark.py \<bitaxe\_ip\> \-v \<initial\_voltage\> \-f \<initial\_frequency\>
+python bitaxe_hashrate_benchmark.py <bitaxe_ip> -v <initial_voltage> -f <initial_frequency>
 ```
 
 **Arguments:**
 
-* \<bitaxe\_ip\>: **Required.** IP address of your Bitaxe miner (e.g., 192.168.2.26).  
-```* \-v, \--voltage:``` **Optional.** Initial voltage in mV for testing (default: 1150).  
-```* \-f, \--frequency:``` **Optional.** Initial frequency in MHz for testing (default: 500).
+* `<bitaxe_ip>`: **Required.** IP address of your Bitaxe miner (e.g., `192.168.2.26`).  
+* `-v, --voltage:` **Optional.** Initial voltage in mV for testing (default: `1150`).  
+* `-f, --frequency:` **Optional.** Initial frequency in MHz for testing (default: `500`).
 
 **Example:**  
 ```bash
-python bitaxe\_hasrate\_benchmark.py 192.168.1.136 \-v 1150 \-f 500
+python bitaxe_hashrate_benchmark.py 192.168.1.136 -v 1150 -f 550
 ```
 
 ### **Apply Specific Settings (Without Benchmarking)**
 
 To quickly apply specific voltage and frequency settings to your Bitaxe without running the full benchmark:  
 ```bash
-python bitaxe\_hasrate\_benchmark.py \<bitaxe\_ip\> \--set-values \-v \<desired\_voltage\_mv\> \-f \<desired\_frequency\_mhz\>
+python bitaxe_hashrate_benchmark.py <bitaxe_ip> --set-values -v <desired_voltage_mv> -f <desired_frequency_mhz>
 ```
 
 **Arguments:**
 
-* \<bitaxe\_ip\>: **Required.** IP address of your Bitaxe miner.  
-```* \-s, \--set-values:``` **Flag.** Activates this mode to only set values and exit.  
-```* \-v, \--voltage:``` **Required.** The exact voltage in mV to apply.  
-```* \-f, \--frequency:``` **Required.** The exact frequency in MHz to apply.
+* `<bitaxe_ip>`: **Required.** IP address of your Bitaxe miner.  
+* `-s, --set-values`: **Flag.** Activates this mode to only set values and exit.  
+* `-v, --voltage`: **Required.** The exact voltage in mV to apply.  
+* `-f, --frequency`: **Required.** The exact frequency in MHz to apply.
 
 **Example:**  
 ```bash
-python bitaxe\_hasrate\_benchmark.py 192.168.1.136 \--set-values \-v 1150 \-f 780
+python bitaxe_hashrate_benchmark.py 192.168.1.136 --set-values -v 1150 -f 780
 ```
 
 ### **Docker Usage (Optional)**
 
-Run the container with your Bitaxe's IP address (add \--set-values for that mode):  
+Run the container with your Bitaxe's IP address (add --set-values for that mode):  
 ```bash
-docker run \--rm bitaxe-benchmark \<bitaxe\_ip\> \[options\]
+docker run --rm bitaxe-benchmark <bitaxe_ip> [options]
 ```
 
 Example (Full Benchmark):  
 ```bash
-docker run \--rm bitaxe-benchmark 192.168.2.26 \-v 1200 \-f 550
+docker run --rm bitaxe-benchmark 192.168.2.26 -v 1200 -f 550
 ```
 
 Example (Set Settings Only):  
 ```bash
-docker run \--rm bitaxe-benchmark 192.168.2.26 \--set-values \-v 1150 \-f 780
+docker run --rm bitaxe-benchmark 192.168.2.26 --set-values -v 1150 -f 780
 ```
 
 ## **Configuration**
 
-The script includes several configurable parameters. These can be adjusted in the bitaxe\_hasrate\_benchmark.py file:
+The script includes several configurable parameters. These can be adjusted in the bitaxe_hashrate_benchmark.py file:
 
 * Maximum chip temperature: 66°C  
 * Maximum VR temperature: 86°C  
@@ -126,11 +122,11 @@ The script includes several configurable parameters. These can be adjusted in th
 * Minimum required samples: 7 (for valid data processing)  
 * Voltage increment: 15mV  
 * Frequency increment: 20MHz  
-* **ASIC Configuration:** asic\_count is hardcoded to 1 as it's not always provided by the API. small\_core\_count is fetched from the Bitaxe.
+* **ASIC Configuration:** asic_count is hardcoded to 1 as it's not always provided by the API. small_core_count is fetched from the Bitaxe.
 
 ## **Output**
 
-The benchmark results are saved to bitaxe\_benchmark\_results\_\<ip\_address\>.json, containing:
+The benchmark results are saved to bitaxe_benchmark_results_<ip_address>.json, containing:
 
 * Complete test results for all combinations  
 * Top 5 performing configurations ranked by hashrate  
@@ -190,11 +186,11 @@ The tool implements several data processing techniques to ensure accurate result
 
 ## **Contributing**
 
-Contributions are welcome\! Please feel free to submit a Pull Request.
+Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## **License**
 
-This project is licensed under the GNU General Public License v3.0 \- see the [LICENSE](https://www.google.com/search?q=LICENSE) file for details.
+This project is licensed under the GNU General Public License v3.0 - see the [LICENSE](https://www.google.com/search?q=LICENSE) file for details.
 
 ## **Disclaimer**
 

--- a/README.md
+++ b/README.md
@@ -68,33 +68,45 @@ python bitaxe\_hasrate\_benchmark.py \<bitaxe\_ip\> \-v \<initial\_voltage\> \-f
 ```* \-f, \--frequency:``` **Optional.** Initial frequency in MHz for testing (default: 500).
 
 **Example:**  
+```
 python bitaxe\_hasrate\_benchmark.py 192.168.1.136 \-v 1150 \-f 500
+```
 
 ### **Apply Specific Settings (Without Benchmarking)**
 
 To quickly apply specific voltage and frequency settings to your Bitaxe without running the full benchmark:  
+```
 python bitaxe\_hasrate\_benchmark.py \<bitaxe\_ip\> \--set-values \-v \<desired\_voltage\_mv\> \-f \<desired\_frequency\_mhz\>
+```
 
 **Arguments:**
 
 * \<bitaxe\_ip\>: **Required.** IP address of your Bitaxe miner.  
-* \-s, \--set-values: **Flag.** Activates this mode to only set values and exit.  
-* \-v, \--voltage: **Required.** The exact voltage in mV to apply.  
-* \-f, \--frequency: **Required.** The exact frequency in MHz to apply.
+```* \-s, \--set-values:``` **Flag.** Activates this mode to only set values and exit.  
+```* \-v, \--voltage:``` **Required.** The exact voltage in mV to apply.  
+```* \-f, \--frequency:``` **Required.** The exact frequency in MHz to apply.
 
 **Example:**  
+```
 python bitaxe\_hasrate\_benchmark.py 192.168.1.136 \--set-values \-v 1150 \-f 780
+```
 
 ### **Docker Usage (Optional)**
 
 Run the container with your Bitaxe's IP address (add \--set-values for that mode):  
+```
 docker run \--rm bitaxe-benchmark \<bitaxe\_ip\> \[options\]
+```
 
 Example (Full Benchmark):  
+```
 docker run \--rm bitaxe-benchmark 192.168.2.26 \-v 1200 \-f 550
+```
 
 Example (Set Settings Only):  
+```
 docker run \--rm bitaxe-benchmark 192.168.2.26 \--set-values \-v 1150 \-f 780
+```
 
 ## **Configuration**
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## **License**
 
-This project is licensed under the GNU General Public License v3.0 - see the [LICENSE](https://www.google.com/search?q=LICENSE) file for details.
+This project is licensed under the GNU General Public License v3.0 - see the [LICENSE](LICENSE) file for details.
 
 ## **Disclaimer**
 

--- a/README.md
+++ b/README.md
@@ -32,16 +32,18 @@ A Python-based benchmarking tool for optimizing Bitaxe mining performance by tes
    ```
 
 2. Create and activate a virtual environment:  
-   `python -m venv venv`
+   ```bash
+   python -m venv venv
    # On Windows  
-   `venvScriptsactivate`
+   venvScriptsactivate
    # On Linux/Mac  
-   `source venv/bin/activate`
-   
+   source venv/bin/activate
+   ```
 
 3. Install dependencies:     
-   `pip install -r requirements.txt`
-
+   ```bash
+   pip install -r requirements.txt
+   ```
 
 ### **Docker Installation**
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ A Python-based benchmarking tool for optimizing Bitaxe mining performance by tes
 ### **Standard Installation**
 
 1. Clone the repository:  
-   ```
+   ```bash
    git clone https://github.com/mrv777/Bitaxe-Hashrate-Benchmark.git  
    cd Bitaxe-Hashrate-Benchmark
    ```
 
 2. Create and activate a virtual environment:  
-   ```
+   ```bash
    python \-m venv venv  
    \# On Windows  
    venv\\Scripts\\activate  
@@ -41,15 +41,15 @@ A Python-based benchmarking tool for optimizing Bitaxe mining performance by tes
    ```
 
 3. Install dependencies:  
-   ```
+   ```bash
    pip install \-r requirements.txt
    ```
 
 ### **Docker Installation**
 
 1. Build the Docker image:  
-   ```
-   docker build \-t bitaxe-benchmark .
+   ```bash
+   docker build \-t bitaxe-benchmark
    ```
 
 ## **Usage**
@@ -57,7 +57,7 @@ A Python-based benchmarking tool for optimizing Bitaxe mining performance by tes
 ### **Standard Usage (Run Full Benchmark)**
 
 Run the benchmark tool by providing your Bitaxe's IP address and initial settings:  
-```
+```bash
 python bitaxe\_hasrate\_benchmark.py \<bitaxe\_ip\> \-v \<initial\_voltage\> \-f \<initial\_frequency\>
 ```
 
@@ -68,14 +68,14 @@ python bitaxe\_hasrate\_benchmark.py \<bitaxe\_ip\> \-v \<initial\_voltage\> \-f
 ```* \-f, \--frequency:``` **Optional.** Initial frequency in MHz for testing (default: 500).
 
 **Example:**  
-```
+```bash
 python bitaxe\_hasrate\_benchmark.py 192.168.1.136 \-v 1150 \-f 500
 ```
 
 ### **Apply Specific Settings (Without Benchmarking)**
 
 To quickly apply specific voltage and frequency settings to your Bitaxe without running the full benchmark:  
-```
+```bash
 python bitaxe\_hasrate\_benchmark.py \<bitaxe\_ip\> \--set-values \-v \<desired\_voltage\_mv\> \-f \<desired\_frequency\_mhz\>
 ```
 
@@ -87,24 +87,24 @@ python bitaxe\_hasrate\_benchmark.py \<bitaxe\_ip\> \--set-values \-v \<desired\
 ```* \-f, \--frequency:``` **Required.** The exact frequency in MHz to apply.
 
 **Example:**  
-```
+```bash
 python bitaxe\_hasrate\_benchmark.py 192.168.1.136 \--set-values \-v 1150 \-f 780
 ```
 
 ### **Docker Usage (Optional)**
 
 Run the container with your Bitaxe's IP address (add \--set-values for that mode):  
-```
+```bash
 docker run \--rm bitaxe-benchmark \<bitaxe\_ip\> \[options\]
 ```
 
 Example (Full Benchmark):  
-```
+```bash
 docker run \--rm bitaxe-benchmark 192.168.2.26 \-v 1200 \-f 550
 ```
 
 Example (Set Settings Only):  
-```
+```bash
 docker run \--rm bitaxe-benchmark 192.168.2.26 \--set-values \-v 1150 \-f 780
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,36 +26,46 @@ A Python-based benchmarking tool for optimizing Bitaxe mining performance by tes
 ### **Standard Installation**
 
 1. Clone the repository:  
+   ```
    git clone https://github.com/mrv777/Bitaxe-Hashrate-Benchmark.git  
    cd Bitaxe-Hashrate-Benchmark
+   ```
 
 2. Create and activate a virtual environment:  
+   ```
    python \-m venv venv  
    \# On Windows  
    venv\\Scripts\\activate  
    \# On Linux/Mac  
    source venv/bin/activate
+   ```
 
 3. Install dependencies:  
+   ```
    pip install \-r requirements.txt
+   ```
 
 ### **Docker Installation**
 
 1. Build the Docker image:  
+   ```
    docker build \-t bitaxe-benchmark .
+   ```
 
 ## **Usage**
 
 ### **Standard Usage (Run Full Benchmark)**
 
 Run the benchmark tool by providing your Bitaxe's IP address and initial settings:  
+```
 python bitaxe\_hasrate\_benchmark.py \<bitaxe\_ip\> \-v \<initial\_voltage\> \-f \<initial\_frequency\>
+```
 
 **Arguments:**
 
 * \<bitaxe\_ip\>: **Required.** IP address of your Bitaxe miner (e.g., 192.168.2.26).  
-* \-v, \--voltage: **Optional.** Initial voltage in mV for testing (default: 1150).  
-* \-f, \--frequency: **Optional.** Initial frequency in MHz for testing (default: 500).
+```* \-v, \--voltage:``` **Optional.** Initial voltage in mV for testing (default: 1150).  
+```* \-f, \--frequency:``` **Optional.** Initial frequency in MHz for testing (default: 500).
 
 **Example:**  
 python bitaxe\_hasrate\_benchmark.py 192.168.1.136 \-v 1150 \-f 500

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Python-based benchmarking tool for optimizing Bitaxe mining performance by tes
 * **Direct setting of specific voltage and frequency from command line**  
 * Temperature monitoring and safety cutoffs  
 * **Power consumption monitoring and reporting (Watts)**  
-* **Fan speed monitoring and reporting (RPM/Percentage)**  
+* **Fan speed monitoring and reporting (Percentage)**  
 * Power efficiency calculations (J/TH)  
 * Automatic saving of benchmark results  
 * Graceful shutdown with best settings retention  

--- a/README.md
+++ b/README.md
@@ -91,17 +91,18 @@ python bitaxe_hashrate_benchmark.py 192.168.1.136 --set-values -v 1150 -f 780
 
 ### **Docker Usage (Optional)**
 
-Run the container with your Bitaxe's IP address (add --set-values for that mode):  
+Run the container with your Bitaxe's IP address (add --set-values for that mode).
+Benchmark results are written to `/results` inside the container — use `-v` to mount a host directory so the results persist after the container exits:
 ```bash
-docker run --rm bitaxe-benchmark <bitaxe_ip> [options]
+docker run --rm -v $(pwd)/results:/results bitaxe-benchmark <bitaxe_ip> [options]
 ```
 
-Example (Full Benchmark):  
+Example (Full Benchmark):
 ```bash
-docker run --rm bitaxe-benchmark 192.168.2.26 -v 1200 -f 550
+docker run --rm -v $(pwd)/results:/results bitaxe-benchmark 192.168.2.26 -v 1200 -f 550
 ```
 
-Example (Set Settings Only):  
+Example (Set Settings Only):
 ```bash
 docker run --rm bitaxe-benchmark 192.168.2.26 --set-values -v 1150 -f 780
 ```

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The script includes several configurable parameters. These can be adjusted in th
 
 ## **Output**
 
-The benchmark results are saved to bitaxe_benchmark_results_<ip_address>.json, containing:
+The benchmark results are saved to `bitaxe_benchmark_results_<ip_address>_<timestamp>.json`, containing:
 
 * Complete test results for all combinations  
 * Top 5 performing configurations ranked by hashrate  

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A Python-based benchmarking tool for optimizing Bitaxe mining performance by tes
 ## **Features**
 
 * Automated benchmarking of different voltage/frequency combinations  
-* **Direct setting of specific voltage and frequency from command line**  
+* Direct setting of specific voltage and frequency from command line
 * Temperature monitoring and safety cutoffs  
-* **Power consumption monitoring and reporting (Watts)**  
-* **Fan speed monitoring and reporting (Percentage)**  
+* Power consumption monitoring and reporting (Watts)
+* Fan speed monitoring and reporting (Percentage)  
 * Power efficiency calculations (J/TH)  
 * Automatic saving of benchmark results  
 * Graceful shutdown with best settings retention  
@@ -125,7 +125,7 @@ The script includes several configurable parameters. These can be adjusted in th
 * Minimum required samples: 7 (for valid data processing)  
 * Voltage increment: 15mV  
 * Frequency increment: 20MHz  
-* **ASIC Configuration:** asic_count is hardcoded to 1 as it's not always provided by the API. small_core_count is fetched from the Bitaxe.
+* ASIC Configuration: asic_count is hardcoded to 1 as it's not always provided by the API. small_core_count is fetched from the Bitaxe.
 
 ## **Output**
 
@@ -139,8 +139,8 @@ The benchmark results are saved to bitaxe_benchmark_results_<ip_address>.json, c
   * Temperature readings (excluding initial warmup period)  
   * VR temperature readings (when available)  
   * Power efficiency metrics (J/TH)  
-  * **Average Power (Watts)**  
-  * **Average Fan Speed (Percentage or RPM, if available from API)**  
+  * Average Power (Watts)
+  * Average Fan Speed (Percentage or RPM, if available from API) 
   * Input voltage measurements  
   * Voltage/frequency combinations tested  
   * Error reason (if any) for a specific iteration
@@ -185,7 +185,7 @@ The tool implements several data processing techniques to ensure accurate result
 * Averages power consumption across entire test period  
 * Monitors VR temperature when available  
 * Calculates efficiency in Joules per Terahash (J/TH)  
-* **Averages fan speed across entire test period**
+* Averages fan speed across entire test period
 
 ## **Contributing**
 

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -16,7 +16,6 @@ except ImportError:
         os.system("")  # rudimentary ANSI enable on Windows
 
 # Compute timestamp for file suffix
-import time
 timestamp = time.strftime("%Y%m%d-%H%M%S")
 
 # ANSI Color Codes

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -5,6 +5,9 @@ import signal
 import sys
 import argparse
 
+import os
+os.system("")  # enables ansi escape characters in terminal - colors were not working in Windows terminal
+
 # ANSI Color Codes
 GREEN = "\033[92m"
 YELLOW = "\033[93m"
@@ -71,6 +74,13 @@ if initial_frequency < min_allowed_frequency:
 
 if benchmark_time / sample_interval < 7:
     raise ValueError(RED + f"Error: Benchmark time is too short. Please increase the benchmark time or decrease the sample interval. At least 7 samples are required." + RESET)
+
+# Add suffix to filename in case of manual initial voltage/frequency
+file_suffix = ""
+if initial_voltage != 1150:
+    file_suffix = file_suffix + " v" + str(initial_voltage)
+if initial_frequency != 500:
+    file_suffix = file_suffix + " f" + str(initial_frequency)
 
 # Results storage
 results = []
@@ -307,7 +317,7 @@ def save_results():
     try:
         # Extract IP from bitaxe_ip global variable and remove 'http://'
         ip_address = bitaxe_ip.replace('http://', '')
-        filename = f"bitaxe_benchmark_results_{ip_address}.json"
+        filename = f"bitaxe_benchmark_results_{ip_address}{file_suffix}.json"
         with open(filename, "w") as f:
             json.dump(results, f, indent=4)
         print(GREEN + f"Results saved to {filename}" + RESET)
@@ -346,12 +356,14 @@ try:
     
     current_voltage = initial_voltage
     current_frequency = initial_frequency
+    retry_upon_overheat = 0
     
     while current_voltage <= max_allowed_voltage and current_frequency <= max_allowed_frequency:
         set_system_settings(current_voltage, current_frequency)
         avg_hashrate, avg_temp, efficiency_jth, hashrate_ok, avg_vr_temp, error_reason = benchmark_iteration(current_voltage, current_frequency)
         
         if avg_hashrate is not None and avg_temp is not None and efficiency_jth is not None:
+            retry_upon_overheat = 0
             result = {
                 "coreVoltage": current_voltage,
                 "frequency": current_frequency,
@@ -370,20 +382,37 @@ try:
                 # If hashrate is good, try increasing frequency
                 if current_frequency + frequency_increment <= max_allowed_frequency:
                     current_frequency += frequency_increment
+                    print(GREEN + "Hashrate is good. Increasing frequency for next try." + RESET)
                 else:
+                    print(GREEN + "Reached max frequency with good results. Stopping further testing." + RESET)
                     break  # We've reached max frequency with good results
             else:
                 # If hashrate is not good, go back one frequency step and increase voltage
                 if current_voltage + voltage_increment <= max_allowed_voltage:
                     current_voltage += voltage_increment
                     current_frequency -= frequency_increment  # Go back to one frequency step and retry
-                    print(YELLOW + f"Hashrate to low compared to expected. Decreasing frequency to {current_frequency}MHz and increasing voltage to {current_voltage}mV" + RESET)
+                    print(YELLOW + f"Hashrate too low compared to expected. Decreasing frequency to {current_frequency}MHz and increasing voltage to {current_voltage}mV" + RESET)
                 else:
+                    print(YELLOW + "Reached max voltage without good results. Stopping further testing." + RESET)
                     break  # We've reached max voltage without good results
         else:
             # If we hit thermal limits or other issues, we've found the highest safe settings
-            print(GREEN + "Reached thermal or stability limits. Stopping further testing." + RESET)
-            break  # Stop testing higher values
+            # In case of max Chip Temperature reached, continue loop to next voltage with decreased frequency
+            # Condition added to avoid successive overheat tries and reset to high initial frequency
+            if avg_hashrate is None and avg_temp is None and efficiency_jth is None and hashrate_ok is False and avg_vr_temp is None and error_reason == 'CHIP_TEMP_EXCEEDED' and initial_frequency <= current_frequency + frequency_increment and retry_upon_overheat < 1:
+                # If overheat, return to initial frequency while increasing voltage (considering max_allowed_voltage)
+                #and current_frequency + frequency_increment <= max_allowed_frequency and current_voltage + voltage_increment <= max_allowed_voltage
+                retry_upon_overheat += 1
+                if current_voltage + voltage_increment <= max_allowed_voltage:
+                    current_frequency = initial_frequency
+                    current_voltage += voltage_increment
+                    print(GREEN + "Reached thermal limit for the current voltage/frequency. Switching to next voltage increment." + RESET)
+                else:
+                    print(GREEN + "Reached thermal limit for the current voltage/frequency. Next voltage increment out of voltage limit. Stopping further testing." + RESET)
+                    break  # We've reached max voltage, can't increase voltage anymore
+            else:
+                print(GREEN + "Reached thermal or stability limits. Stopping further testing." + RESET)
+                break  # Stop testing higher values
 
         save_results()
 
@@ -445,7 +474,7 @@ finally:
         
         # Save the final data to JSON
         ip_address = bitaxe_ip.replace('http://', '')
-        filename = f"bitaxe_benchmark_results_{ip_address}.json"
+        filename = f"bitaxe_benchmark_results_{ip_address}{file_suffix}.json"
         with open(filename, "w") as f:
             json.dump(final_data, f, indent=4)
         
@@ -495,3 +524,4 @@ def cleanup_and_exit(reason=None):
             print(RED + f"Benchmarking stopped: {reason}" + RESET)
         print(GREEN + "Benchmarking completed." + RESET)
         sys.exit(0)
+

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -20,6 +20,10 @@ def parse_arguments():
     parser.add_argument('-f', '--frequency', type=int, default=500,
                        help='Initial frequency in MHz (default: 500)')
     
+    # Add a new argument for setting values only
+    parser.add_argument('-s', '--set-values', action='store_true', 
+                        help='Set values only, do not benchmark. Apply specified voltage and frequency settings to Bitaxe and exit')
+    
     # If no arguments are provided, print help and exit
     if len(sys.argv) == 1:
         parser.print_help()
@@ -349,6 +353,17 @@ def reset_to_best_setting():
         set_system_settings(best_voltage, best_frequency)
     
     restart_system()
+
+# --- Main execution logic ---
+if args.set_values:
+    print(GREEN + "\n--- Applying Settings Only ---" + RESET)
+    print(GREEN + f"Applying Core Voltage: {initial_voltage}mV, Frequency: {initial_frequency}MHz to Bitaxe." + RESET)
+    
+    # Call the existing set_system_settings function
+    set_system_settings(initial_voltage, initial_frequency)
+    
+    print(GREEN + "Settings applied. Check your Bitaxe web interface to confirm." + RESET)
+    sys.exit(0) # Exit the script after applying settings
 
 # Main benchmarking process
 try:

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -311,7 +311,7 @@ def benchmark_iteration(core_voltage, frequency):
             f"CV: {core_voltage:4d}mV | "
             f"F: {frequency:4d}MHz | "
             f"H: {int(hash_rate):4d} GH/s | "
-            f"SD: {running_sd:.2f} GH/s | "
+            f"SD: {running_sd:3.0f} GH/s | "
             f"IV: {int(voltage):4d}mV | "
             f"T: {int(temp):2d}°C"
         )

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -34,8 +34,8 @@ initial_voltage = args.voltage
 initial_frequency = args.frequency
 
 # Configuration
-voltage_increment = 20
-frequency_increment = 25
+voltage_increment = 15
+frequency_increment = 20
 benchmark_time = 600          # 10 minutes benchmark time
 sample_interval = 15          # 15 seconds sample interval
 max_temp = 66                 # Will stop if temperature reaches or exceeds this value
@@ -44,11 +44,11 @@ max_allowed_frequency = 1200  # Maximum allowed core frequency
 max_vr_temp = 86              # Maximum allowed voltage regulator temperature
 min_input_voltage = 4800      # Minimum allowed input voltage
 max_input_voltage = 5500      # Maximum allowed input voltage
-max_power = 40                # Max of 40W because of DC plug
+max_power = 30                # Max of 30W because of DC plug
 
 # Add these variables to the global configuration section
 small_core_count = None
-asic_count = None
+asic_count = 1
 
 # Add these constants to the configuration section
 min_allowed_voltage = 1000  # Minimum allowed core voltage
@@ -187,8 +187,9 @@ def benchmark_iteration(core_voltage, frequency):
     print(GREEN + f"[{current_time}] Starting benchmark for Core Voltage: {core_voltage}mV, Frequency: {frequency}MHz" + RESET)
     hash_rates = []
     temperatures = []
-    power_consumptions = []
+    power_consumptions = [] 
     vr_temps = []
+    fan_speeds = []
     total_samples = benchmark_time // sample_interval
     expected_hashrate = frequency * ((small_core_count * asic_count) / 1000)  # Calculate expected hashrate based on frequency
     
@@ -196,52 +197,55 @@ def benchmark_iteration(core_voltage, frequency):
         info = get_system_info()
         if info is None:
             print(YELLOW + "Skipping this iteration due to failure in fetching system info." + RESET)
-            return None, None, None, False, None, "SYSTEM_INFO_FAILURE"
+            return None, None, None, False, None, None, None, "SYSTEM_INFO_FAILURE"
         
         temp = info.get("temp")
         vr_temp = info.get("vrTemp")  # Get VR temperature if available
         voltage = info.get("voltage")
         if temp is None:
             print(YELLOW + "Temperature data not available." + RESET)
-            return None, None, None, False, None, "TEMPERATURE_DATA_FAILURE"
+            return None, None, None, False, None, None, None, "TEMPERATURE_DATA_FAILURE"
         
         if temp < 5:
             print(YELLOW + "Temperature is below 5°C. This is unexpected. Please check the system." + RESET)
-            return None, None, None, False, None, "TEMPERATURE_BELOW_5"
+            return None, None, None, False, None, None, None, "TEMPERATURE_BELOW_5"
         
         # Check both chip and VR temperatures
         if temp >= max_temp:
             print(RED + f"Chip temperature exceeded {max_temp}°C! Stopping current benchmark." + RESET)
-            return None, None, None, False, None, "CHIP_TEMP_EXCEEDED"
+            return None, None, None, False, None, None, None, "CHIP_TEMP_EXCEEDED"
             
         if vr_temp is not None and vr_temp >= max_vr_temp:
             print(RED + f"Voltage regulator temperature exceeded {max_vr_temp}°C! Stopping current benchmark." + RESET)
-            return None, None, None, False, None, "VR_TEMP_EXCEEDED"
+            return None, None, None, False, None, None, None, "VR_TEMP_EXCEEDED"
 
         if voltage < min_input_voltage:
             print(RED + f"Input voltage is below the minimum allowed value of {min_input_voltage}mV! Stopping current benchmark." + RESET)
-            return None, None, None, False, None, "INPUT_VOLTAGE_BELOW_MIN"
+            return None, None, None, False, None, None, None, "INPUT_VOLTAGE_BELOW_MIN"
         
         if voltage > max_input_voltage:
             print(RED + f"Input voltage is above the maximum allowed value of {max_input_voltage}mV! Stopping current benchmark." + RESET)
-            return None, None, None, False, None, "INPUT_VOLTAGE_ABOVE_MAX"
+            return None, None, None, False, None, None, None, "INPUT_VOLTAGE_ABOVE_MAX"
         
         hash_rate = info.get("hashRate")
         power_consumption = info.get("power")
-        
+        fan_speed = info.get("fanspeed")    
+
         if hash_rate is None or power_consumption is None:
             print(YELLOW + "Hashrate or Watts data not available." + RESET)
-            return None, None, None, False, None, "HASHRATE_POWER_DATA_FAILURE"
+            return None, None, None, False, None, None, None, "HASHRATE_POWER_DATA_FAILURE"
         
         if power_consumption > max_power:
             print(RED + f"Power consumption exceeded {max_power}W! Stopping current benchmark." + RESET)
-            return None, None, None, False, None, "POWER_CONSUMPTION_EXCEEDED"
+            return None, None, None, False, None, None, None, "POWER_CONSUMPTION_EXCEEDED"
         
         hash_rates.append(hash_rate)
         temperatures.append(temp)
         power_consumptions.append(power_consumption)
         if vr_temp is not None and vr_temp > 0:
             vr_temps.append(vr_temp)
+        if fan_speed is not None:
+            fan_speeds.append(fan_speed)
 
         # Calculate percentage progress
         percentage_progress = ((sample + 1) / total_samples) * 100
@@ -256,6 +260,15 @@ def benchmark_iteration(core_voltage, frequency):
         )
         if vr_temp is not None and vr_temp > 0:
             status_line += f" | VR: {int(vr_temp):2d}°C"
+
+        # Add Power (Watts) to the status line if available
+        if power_consumption is not None:
+            status_line += f" | P: {int(power_consumption):2d} W"
+
+        # Add Fan Speed to the status line if available
+        if fan_speed is not None:
+            status_line += f" | FAN: {int(fan_speed):2d}%"
+
         print(status_line + RESET)
         
         # Only sleep if it's not the last iteration
@@ -281,13 +294,18 @@ def benchmark_iteration(core_voltage, frequency):
             average_vr_temp = sum(trimmed_vr_temps) / len(trimmed_vr_temps)
         
         average_power = sum(power_consumptions) / len(power_consumptions)
+
+        average_fan_speed = None
+        if fan_speeds:
+            average_fan_speed = sum(fan_speeds) / len(fan_speeds)
+            print(GREEN + f"Average Fan Speed: {average_fan_speed:.2f}%" + RESET)
         
         # Add protection against zero hashrate
         if average_hashrate > 0:
             efficiency_jth = average_power / (average_hashrate / 1_000)
         else:
             print(RED + "Warning: Zero hashrate detected, skipping efficiency calculation" + RESET)
-            return None, None, None, False, None, "ZERO_HASHRATE"
+            return None, None, None, False, None, None, None, "ZERO_HASHRATE"
         
         # Calculate if hashrate is within 6% of expected
         hashrate_within_tolerance = (average_hashrate >= expected_hashrate * 0.94)
@@ -298,10 +316,10 @@ def benchmark_iteration(core_voltage, frequency):
             print(GREEN + f"Average VR Temperature: {average_vr_temp:.2f}°C" + RESET)
         print(GREEN + f"Efficiency: {efficiency_jth:.2f} J/TH" + RESET)
         
-        return average_hashrate, average_temperature, efficiency_jth, hashrate_within_tolerance, average_vr_temp, None
+        return average_hashrate, average_temperature, efficiency_jth, hashrate_within_tolerance, average_vr_temp, average_power, average_fan_speed, None
     else:
         print(YELLOW + "No Hashrate or Temperature or Watts data collected." + RESET)
-        return None, None, None, False, None, "NO_DATA_COLLECTED"
+        return None, None, None, False, None, None, None, "NO_DATA_COLLECTED"
 
 def save_results():
     try:
@@ -349,7 +367,7 @@ try:
     
     while current_voltage <= max_allowed_voltage and current_frequency <= max_allowed_frequency:
         set_system_settings(current_voltage, current_frequency)
-        avg_hashrate, avg_temp, efficiency_jth, hashrate_ok, avg_vr_temp, error_reason = benchmark_iteration(current_voltage, current_frequency)
+        avg_hashrate, avg_temp, efficiency_jth, hashrate_ok, avg_vr_temp, avg_power, avg_fan_speed, error_reason = benchmark_iteration(current_voltage, current_frequency)
         
         if avg_hashrate is not None and avg_temp is not None and efficiency_jth is not None:
             result = {
@@ -357,12 +375,18 @@ try:
                 "frequency": current_frequency,
                 "averageHashRate": avg_hashrate,
                 "averageTemperature": avg_temp,
-                "efficiencyJTH": efficiency_jth
+                "efficiencyJTH": efficiency_jth,
+                "averagePower": avg_power,
+                "errorReason": error_reason
             }
             
             # Only add VR temp if it exists
             if avg_vr_temp is not None:
                 result["averageVRTemp"] = avg_vr_temp
+
+            # Only add Fan Speed if it exists (assuming it's not None)
+            if avg_fan_speed is not None:
+                result["averageFanSpeed"] = avg_fan_speed
                 
             results.append(result)
 
@@ -425,7 +449,9 @@ finally:
                     "averageHashRate": result["averageHashRate"],
                     "averageTemperature": result["averageTemperature"],
                     "efficiencyJTH": result["efficiencyJTH"],
-                    **({"averageVRTemp": result["averageVRTemp"]} if "averageVRTemp" in result else {})
+                    "averagePower": result["averagePower"],
+                    **({"averageVRTemp": result["averageVRTemp"]} if "averageVRTemp" in result else {}),
+                    **({"averageFanSpeed": result["averageFanSpeed"]} if "averageFanSpeed" in result else {})
                 }
                 for i, result in enumerate(top_5_results, 1)
             ],
@@ -437,7 +463,9 @@ finally:
                     "averageHashRate": result["averageHashRate"],
                     "averageTemperature": result["averageTemperature"],
                     "efficiencyJTH": result["efficiencyJTH"],
-                    **({"averageVRTemp": result["averageVRTemp"]} if "averageVRTemp" in result else {})
+                    "averagePower": result["averagePower"],
+                    **({"averageVRTemp": result["averageVRTemp"]} if "averageVRTemp" in result else {}),
+                    **({"averageFanSpeed": result["averageFanSpeed"]} if "averageFanSpeed" in result else {})
                 }
                 for i, result in enumerate(top_5_efficient_results, 1)
             ]
@@ -459,6 +487,9 @@ finally:
                 print(GREEN + f"  Average Hashrate: {result['averageHashRate']:.2f} GH/s" + RESET)
                 print(GREEN + f"  Average Temperature: {result['averageTemperature']:.2f}°C" + RESET)
                 print(GREEN + f"  Efficiency: {result['efficiencyJTH']:.2f} J/TH" + RESET)
+                print(GREEN + f"  Average Power: {result['averagePower']:.2f} W" + RESET)
+                if "averageFanSpeed" in result:
+                    print(GREEN + f"  Average Fan Speed: {result['averageFanSpeed']:.2f}%" + RESET)
                 if "averageVRTemp" in result:
                     print(GREEN + f"  Average VR Temperature: {result['averageVRTemp']:.2f}°C" + RESET)
             
@@ -470,6 +501,9 @@ finally:
                 print(GREEN + f"  Average Hashrate: {result['averageHashRate']:.2f} GH/s" + RESET)
                 print(GREEN + f"  Average Temperature: {result['averageTemperature']:.2f}°C" + RESET)
                 print(GREEN + f"  Efficiency: {result['efficiencyJTH']:.2f} J/TH" + RESET)
+                print(GREEN + f"  Average Power: {result['averagePower']:.2f} W" + RESET)
+                if "averageFanSpeed" in result:
+                    print(GREEN + f"  Average Fan Speed: {result['averageFanSpeed']:.2f}%" + RESET)
                 if "averageVRTemp" in result:
                     print(GREEN + f"  Average VR Temperature: {result['averageVRTemp']:.2f}°C" + RESET)
         else:

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -676,7 +676,6 @@ except Exception as e:
     else:
         print(YELLOW + "No valid benchmarking results found. Applying predefined default settings." + RESET)
         set_system_settings(default_voltage, default_frequency)
-        restart_system()
 finally:
     if not system_reset_done:
         if results:
@@ -686,7 +685,6 @@ finally:
         else:
             print(YELLOW + "No valid benchmarking results found. Applying predefined default settings." + RESET)
             set_system_settings(default_voltage, default_frequency)
-            restart_system()
         system_reset_done = True
 
     # Print results summary only if we have results

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -176,7 +176,8 @@ handling_interrupt = False
 
 def running_stddev(N, s1, s2):
     if N > 1:
-        return ((N * s2 - s1 ** 2) / (N * (N - 1))) ** 0.5
+        var = (N * s2 - s1 ** 2) / (N * (N - 1))
+        return max(var, 0.0) ** 0.5
     else:
         return 0.0
 

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -332,9 +332,14 @@ def restart_system():
                     if info:
                         temp = info.get("temp")
                         power = info.get("power")
+                        vr_temp = info.get("vrTemp")
                         
                         if temp and temp >= max_temp:
                             print(RED + f"CRITICAL: Chip temperature {temp}°C exceeded limit {max_temp}°C during stabilization!" + RESET)
+                            return False
+
+                        if vr_temp and vr_temp >= max_vr_temp:
+                            print(RED + f"CRITICAL: VR temperature {vr_temp}°C exceeded limit {max_vr_temp}°C during stabilization!" + RESET)
                             return False
                             
                         if power and power > max_power:

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -627,6 +627,13 @@ try:
             # If we hit thermal limits or other issues, we've found the highest safe settings
             # In case of max Chip Temperature reached, continue loop to next voltage with decreased frequency
             # Condition added to avoid successive overheat tries and reset to high initial frequency
+            
+            # CRITICAL SAFETY CHECK: If we overheated at the INITIAL frequency, do NOT increase voltage.
+            # Increasing voltage will only make it hotter. We should stop or decrease frequency.
+            if error_reason == "CHIP_TEMP_EXCEEDED" and current_frequency == initial_frequency:
+                print(RED + "Overheated at initial frequency! Cannot increase voltage safely. Stopping." + RESET)
+                break
+
             overheat_retry_allowed = (
                 error_reason == "CHIP_TEMP_EXCEEDED"
                 and retry_upon_overheat < 1

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -102,6 +102,14 @@ def parse_arguments():
              "  The benchmark will stop if this temperature is exceeded."
     )
 
+    parser.add_argument(
+        '-o', '--output-dir',
+        type=str,
+        default='.',
+        help=f"{YELLOW}Directory to save benchmark results to.{RESET}\n"
+             "  Useful for Docker volume mounts (default: current directory)."
+    )
+
     # If no arguments are provided, print help and exit
     if len(sys.argv) == 1:
         parser.print_help()
@@ -118,6 +126,9 @@ if args.bitaxe_ip is None:
     sys.exit(1)
 
 bitaxe_ip = f"http://{args.bitaxe_ip}"
+
+# Create output directory if it doesn't exist
+os.makedirs(args.output_dir, exist_ok=True)
 
 # Logic for voltage and frequency defaults/requirements
 if args.set_values:
@@ -182,7 +193,8 @@ if initial_frequency != 500:
 def result_filename():
     # Extract IP from bitaxe_ip global variable and remove 'http://'
     ip_address = bitaxe_ip.replace('http://', '')
-    return f"bitaxe_benchmark_results_{ip_address}_{timestamp}{file_suffix}.json"
+    name = f"bitaxe_benchmark_results_{ip_address}_{timestamp}{file_suffix}.json"
+    return os.path.join(args.output_dir, name)
 
 # Results storage
 results = []

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -612,8 +612,14 @@ try:
                 # If hashrate is not good, go back one frequency step and increase voltage
                 if current_voltage + voltage_increment <= max_allowed_voltage:
                     current_voltage += voltage_increment
-                    current_frequency -= frequency_increment  # Go back to one frequency step and retry
-                    print(YELLOW + f"Hashrate too low compared to expected. Decreasing frequency to {current_frequency}MHz and increasing voltage to {current_voltage}mV" + RESET)
+                    
+                    # Decrease frequency but respect the minimum limit
+                    if current_frequency - frequency_increment >= min_allowed_frequency:
+                        current_frequency -= frequency_increment
+                    else:
+                        current_frequency = min_allowed_frequency
+                        
+                    print(YELLOW + f"Hashrate too low compared to expected. Adjusting to {current_frequency}MHz and increasing voltage to {current_voltage}mV" + RESET)
                 else:
                     print(YELLOW + "Reached max voltage without good results. Stopping further testing." + RESET)
                     break  # We've reached max voltage without good results

--- a/bitaxe_hashrate_benchmark.py
+++ b/bitaxe_hashrate_benchmark.py
@@ -98,6 +98,14 @@ def parse_arguments():
              "  frequency (-f) settings to the Bitaxe and then exit."
     )
 
+    parser.add_argument(
+        '--max-temp',
+        type=int,
+        default=66,
+        help=f"{YELLOW}Maximum chip temperature in °C (default: 66).{RESET}\n"
+             "  The benchmark will stop if this temperature is exceeded."
+    )
+
     # If no arguments are provided, print help and exit
     if len(sys.argv) == 1:
         parser.print_help()
@@ -117,7 +125,7 @@ frequency_increment = 20
 sleep_time = 90               # Wait 90 seconds before starting the benchmark
 benchmark_time = 600          # 10 minutes benchmark time
 sample_interval = 15          # 15 seconds sample interval
-max_temp = 66                 # Will stop if temperature reaches or exceeds this value
+max_temp = args.max_temp      # Will stop if temperature reaches or exceeds this value
 max_allowed_voltage = 1400    # Maximum allowed core voltage
 max_allowed_frequency = 1200  # Maximum allowed core frequency
 max_vr_temp = 86              # Maximum allowed voltage regulator temperature
@@ -533,7 +541,7 @@ def reset_to_best_setting():
         print(GREEN + f"\nApplying Best Hashrate settings..." + RESET)
         set_system_settings(best_voltage, best_frequency)
     
-    restart_system()
+    # restart_system() is already called inside set_system_settings, so we don't need to call it again here.
 
 # --- Main execution logic ---
 if args.set_values:


### PR DESCRIPTION
## Summary
- Adds `ENV PYTHONUNBUFFERED=1` to the Dockerfile so container logs appear in real-time
- Without this, Python fully buffers stdout when not connected to a TTY, causing `docker logs -f` to show nothing until the container exits

## Depends on
- #9 (this branch is rebased on top of PR #9)

## Test plan
- [ ] Build the Docker image and run the container
- [ ] Verify `docker logs -f <container>` shows output in real-time during benchmarking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "--set-values" apply-only mode and richer CLI controls (IP, max-temp, output-dir).
  * Expanded output metrics: hashrate standard deviation, average power, and average fan speed.
  * Results files now include timestamped filenames and selectable output directory.

* **Bug Fixes / Reliability**
  * Improved runtime stability and safer benchmarking with restart/retry handling and better stabilization checks.

* **Documentation**
  * Major README overhaul with detailed CLI, Docker, configuration, and usage examples.

* **Chores**
  * Docker: streaming logs enabled and default /results directory exposed as a volume.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->